### PR TITLE
Renaming ca locations (put in candata) to california

### DIFF
--- a/_data/locations.csv
+++ b/_data/locations.csv
@@ -47,7 +47,7 @@ caulfield east vic 3145 australia,-37.881276,145.0420847,1
 "madison, wi",43.074761,-89.3837613,6
 "houston, tx",29.7589382,-95.3676974,1
 "charlottesville, va",38.029306,-78.4766781,1
-"livermore, california",37.6820583,-121.7680531,4
+"livermore, california",37.6820583,-121.7680531,6
 "huntingdon, united kingdom",52.3314292,-0.1847723,1
 "clifton park, ny",42.8656325,-73.7709535,2
 "lemont, il",40.8106174,-77.8183337,3
@@ -63,7 +63,7 @@ caulfield east vic 3145 australia,-37.881276,145.0420847,1
 "dallas, tx",32.7762719,-96.7968559,3
 "rocquencourt, france",49.6502698,2.4172616,1
 "gunnison, co",38.6476702,-107.0603126,1
-"santa monica, ca",46.724362,-75.559685,1
+"santa monica, california",34.0250724,-118.4965129,2
 "haverford, pa",40.0131672,-75.2943516,1
 "orlando, fl",28.5421109,-81.3790304,4
 "waterloo, ontario, canada, n2l 2y5",43.466874,-80.524635,2
@@ -74,14 +74,12 @@ caulfield east vic 3145 australia,-37.881276,145.0420847,1
 "amherst, ma",42.3685658,-72.505714,1
 "oakton, va",38.896729,-77.29866437219505,1
 "socorro, nm",34.0572858,-106.8930799,1
-"santa monica, california",34.0250724,-118.4965129,1
 "orange, california",33.7500378,-117.8704931,1
 "nashville, tn",36.1622296,-86.7743531,2
 "tuscon, az",32.1975976,-111.0808672,1
 "ann arbor, mi",42.2681569,-83.7312291,2
 "montreal, canada",45.4972159,-73.6103642,1
-"menlo park, ca",37.4519671,-122.1779927,1
-"menlo park, california",37.4519671,-122.1779927,5
+"menlo park, california",37.4519671,-122.1779927,6
 "nethergate, dundee dd1 4hn, united kingdom",56.4573119,-2.9758871,1
 "honolulu, hi",21.304547,-157.8556764,1
 "durham, nh",43.134564,-70.927048,1
@@ -121,19 +119,18 @@ islamabad,33.6938118,73.0651511,1
 "tuscaloosa, al",33.2095614,-87.5675258,1
 "london, uk",51.5073219,-0.1276474,1
 swansea,51.6195955,-3.9459248,1
-"san francisco, ca",46.8443248,-71.2743272,1
-"livermore, ca",37.6820583,-121.7680531,2
-"glendale, ca",45.8161189,-61.314011,1
+"san francisco, california",37.7790262,-122.4199061,1
+"glendale, california",34.1469416,-118.2478471,1
 "fayetteville, ar",36.0625843,-94.1574328,1
-"santa cruz, ca",37.050096,-121.9905908,1
+"santa cruz, california",37.050096,-121.9905908,1
 "oxford, uk",51.7520131,-1.2578499,1
 "indianapolis, in",39.7683331,-86.1583502,1
 "raleigh, nc",35.7803977,-78.6390989,1
 "lubbock, tx",33.5635206,-101.879336,1
 "kennesaw, ga",34.0234337,-84.6154897,1
 "fairfax, va",38.8462236,-77.3063733,1
-"la jolla, ca",32.83259,-117.2716839,1
-"redwood city, ca",37.4863239,-122.2325233,1
+"la jolla, california",32.83259,-117.2716839,1
+"redwood city, california",37.4863239,-122.2325233,1
 "tucson, az",32.2228765,-110.9748477,1
 "arlington, va",38.8903961,-77.0841585,1
 "lenoir city, tn",35.7972998,-84.2560299,1


### PR DESCRIPTION
The geolocation is off for new California cities given using the name CA, so this fixes it to be California.

Signed-off-by: vsoch <vsochat@stanford.edu>